### PR TITLE
Added Callback functionality

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -111,3 +111,13 @@ void SocketIoClient::trigger(const char* event, const char * payload, size_t len
 		SOCKETIOCLIENT_DEBUG("[SIoC] event %s not found. %d events available\n", event, _events.size());
 	}
 }
+void SocketIoClient::callback(const char * payload) {
+	String msg = String("43") + id + "[";
+	if(payload) {
+		msg += payload;
+	}
+	msg += "]";
+	SOCKETIOCLIENT_DEBUG("[SIoC] callback packet %s\n", msg.c_str());
+	_packets.push_back(msg);
+	id="";
+}

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -21,6 +21,10 @@ const String SocketIoClient::getEventPayload(const String msg) {
 	return result;
 }
 
+void SocketIoClient::getId(const String msg) {
+	id=msg.substring(2, msg.indexOf("["));
+	SOCKETIOCLIENT_DEBUG("[SIoC] event id: %s\n",  id.c_str());
+}
 void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
 	String msg;
 	switch(type) {
@@ -34,6 +38,7 @@ void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t len
 		case WStype_TEXT:
 			msg = String((char*)payload);
 			if(msg.startsWith("42")) {
+				getId(msg);
 				trigger(getEventName(msg).c_str(), getEventPayload(msg).c_str(), length);
 			} else if(msg.startsWith("2")) {
 				_webSocket.sendTXT("3");

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -11,7 +11,7 @@ const String SocketIoClient::getEventName(const String msg) {
 }
 
 const String SocketIoClient::getEventPayload(const String msg) {
-	String result = msg.substring(msg.indexOf("\"",4)+2,msg.length()-1);
+	String result = msg.substring(msg.indexOf(",")+1,msg.length()-1);
 	if(result.startsWith("\"")) {
 		result.remove(0,1);
 	}

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -1,7 +1,13 @@
 #include <SocketIoClient.h>
 
 const String getEventName(const String msg) {
-	return msg.substring(4, msg.indexOf("\"",4));
+	int firstQuote=msg.indexOf("\"");
+	int secondQuote=msg.indexOf("\"",firstQuote+1);
+	if (secondQuote>firstQuote){
+		return msg.substring(firstQuote+1, secondQuote);
+	} else{
+		return "UNKNOWN";
+	}
 }
 
 const String getEventPayload(const String msg) {

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -1,6 +1,6 @@
 #include <SocketIoClient.h>
 
-const String getEventName(const String msg) {
+const String SocketIoClient::getEventName(const String msg) {
 	int firstQuote=msg.indexOf("\"");
 	int secondQuote=msg.indexOf("\"",firstQuote+1);
 	if (secondQuote>firstQuote){
@@ -10,7 +10,7 @@ const String getEventName(const String msg) {
 	}
 }
 
-const String getEventPayload(const String msg) {
+const String SocketIoClient::getEventPayload(const String msg) {
 	String result = msg.substring(msg.indexOf("\"",4)+2,msg.length()-1);
 	if(result.startsWith("\"")) {
 		result.remove(0,1);

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -41,6 +41,7 @@ public:
 	void loop();
 	void on(const char* event, std::function<void (const char * payload, size_t length)>);
 	void emit(const char* event, const char * payload = NULL);
+	void callback(const char * payload);
 };
 
 #endif

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -30,8 +30,9 @@ private:
 
 	void trigger(const char* event, const char * payload, size_t length);
 	void webSocketEvent(WStype_t type, uint8_t * payload, size_t length);
-    void initialize();
-public:
+    	void initialize();
+	const String getEventPayload(const String msg);
+	const String getEventName(const String msg);public:
     void beginSSL(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL, const char* fingerprint = DEFAULT_FINGERPRINT);
 	void begin(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL);
 	void loop();

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -32,7 +32,10 @@ private:
 	void webSocketEvent(WStype_t type, uint8_t * payload, size_t length);
     	void initialize();
 	const String getEventPayload(const String msg);
-	const String getEventName(const String msg);public:
+	const String getEventName(const String msg);
+	void getId(const String msg);
+	String id;
+public:
     void beginSSL(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL, const char* fingerprint = DEFAULT_FINGERPRINT);
 	void begin(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL);
 	void loop();


### PR DESCRIPTION
Socket.io has the ability to fire an event on a client, then have that client respond back within the same request scope. It's REALLY confusing how it works, but I seem to have to gotten it working on my system. 

It does this with the use of IDs. Instead of the packet starting with 42[ it will start with 42{id}[ For example, it may be: 425[ or 429[ This callback method will emit a packet back to the server with
43{id}[ If the server emitted 425[ then the callback would be 435[

This is extremely useful with node.js code like this:

```
socketId='-P5-l_UggL0uM0yoAAAB';
io.sockets.connected[socketId].emit('getAccessPoints',{},function(accessPoints){
	console.log(accessPoints);
});
```

Then in the Arduino code, it looks like this:

```
webSocket.on("getAccessPoints", getAccessPoints);
void getAccessPoints(const char * payload, size_t length) {
  String accessPointsJson="{\"HP-Print-b1-LaserJet 200 color\":\"-51\",\"Aslan\":\"-90\",\"gibbon.net\":\"-68\"}";
  webSocket.callback(accessPointsJson.c_str());
}
```

Two things are happening here, the socket.io server is emitting the
"getAccessPoints" to the arduino board, then the arduino board is
responding BACk to the server with the variable "accessPoints"

So the server is sending something like:
425[{"getAccessPoints"}]

The arduino is responding with:
435[{"HP-Print-b1-LaserJet 200
color":"-51","Aslan":"-90","gibbon.net":"-68"}]

I'll add a full example of it in action shortly.