### PR TITLE
Bump version to 0.2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SocketIoClient
-version=0.1
+version=0.2
 author=Vincent Wyszynski
 maintainer=Vincent Wyszynski
 sentence=socket.io Client for ESP8266 and Arduino


### PR DESCRIPTION
Platformio can't download latest changes because the library version wasn't bumped to the latest tag version.