### PR TITLE
Add HTTP Basic auth support based on arduinoWebSockets Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ socket.emit("jsonObject", "{\"foo\":\"bar\"}");
 ### SocketIoClient::loop()
 processes the websocket. Should be called in Arduino main loop.
 
+### SocketIoClient::setAuthorization(username, password)
+set HTTP Basic auth username and password.
+##### Example
+```c
+socket.setAuthorization("username", "password");
+```
+
 ## Misc
 To go along with the socket.io-client implementation of socket.io the ```connect``` event is triggered upon successfully opened connection to server. To utilize simply add
 ```

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -107,3 +107,7 @@ void SocketIoClient::disconnect()
 	_webSocket.disconnect();
 	trigger("disconnect", NULL, 0);
 }
+
+void SocketIoClient::setAuthorization(const char * user, const char * password) {
+    _webSocket.setAuthorization(user, password);
+}

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -38,6 +38,7 @@ public:
 	void on(const char* event, std::function<void (const char * payload, size_t length)>);
 	void emit(const char* event, const char * payload = NULL);
 	void disconnect();
+	void setAuthorization(const char * user, const char * password);
 };
 
 #endif

--- a/examples/BasicExample/BasicExample.ino
+++ b/examples/BasicExample/BasicExample.ino
@@ -37,6 +37,8 @@ void setup() {
 
     webSocket.on("event", event);
     webSocket.begin("my.socket-io.server");
+    // use HTTP Basic Authorization this is optional remove if not needed
+    webSocket.setAuthorization("username", "password");
 }
 
 void loop() {


### PR DESCRIPTION
Sometimes HTTP Basic auth will be helpful to validate the identity of devices.  And there already has an implementation in the arduinoWebSockets Library.