### PR TITLE
Update SocketIoClient.cpp

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -30,6 +30,7 @@ void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t len
 	switch(type) {
 		case WStype_DISCONNECTED:
 			SOCKETIOCLIENT_DEBUG("[SIoC] Disconnected!\n");
+			disconnect();
 			break;
 		case WStype_CONNECTED:
 			SOCKETIOCLIENT_DEBUG("[SIoC] Connected to url: %s\n",  payload);


### PR DESCRIPTION
When server closes connection the "disconnect" event never is called. Adding that line (33) the event "disconnected" is triggered when server closes the connection, calling the function in the line 125.