### PR TITLE
setExtraHeaders support

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -136,3 +136,7 @@ void SocketIoClient::setExtraHeaders(const char * headers)
 {
     _webSocket.setExtraHeaders(headers);
 }
+
+bool SocketIoClient::isConnected() {
+	return _webSocket.isConnected();
+}

--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -130,3 +130,9 @@ void SocketIoClient::disconnect()
 void SocketIoClient::setAuthorization(const char * user, const char * password) {
     _webSocket.setAuthorization(user, password);
 }
+
+
+void SocketIoClient::setExtraHeaders(const char * headers)
+{
+    _webSocket.setExtraHeaders(headers);
+}

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -44,6 +44,7 @@ public:
 	void disconnect();
 	void setAuthorization(const char * user, const char * password);
 	void setExtraHeaders(const char * headers);
+	bool isConnected(void);
 };
 
 #endif

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -43,6 +43,7 @@ public:
 	void remove(const char* event);
 	void disconnect();
 	void setAuthorization(const char * user, const char * password);
+	void setExtraHeaders(const char * headers);
 };
 
 #endif


### PR DESCRIPTION
Add support for extraHeaders.

Useful for connecting to SocketIO servers that use session-based authentication (i.e., the SocketIO authentication comes from a shared server framework)

Usage:
```cpp
...
#include <WebSocketsClient.h>
#include <SocketIoClient.h>

SocketIoClient webSocket;
...
void setup() {
  // get token, etc., deliminate headers with \n
  char* headers = "Origin: https://someplace.com\n Cookie: SESSION=1234";
  ...
  webSocket.on("event", eventHandler);
  webSocket.setExtraHeaders(headers);
  webSocket.beginSSL("my.server.com", 443, "/socket.io/?transport=websocket", rootFingerprint);
}
```