### PR TITLE
fix disconnect event

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -43,7 +43,7 @@ void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t len
 			} else if(msg.startsWith("40")) {
 				trigger("connect", NULL, 0);
 			} else if(msg.startsWith("41")) {
-				trigger("disconnect", NULL, 0);
+				disconnect();
 			}
 			break;
 		case WStype_BIN:


### PR DESCRIPTION
When the server disconnects the user, the library does not disconnect the webSocket. With this change, the user can reconnect again.