### PR TITLE
type conversion from char to uint_8

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -54,7 +54,7 @@ void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t len
 }
 
 void SocketIoClient::beginSSL(const char* host, const int port, const char* url, const char* fingerprint) {
-	_webSocket.beginSSL(host, port, url, fingerprint);
+	_webSocket.beginSSL(host, port, url, (const uint_8*)fingerprint);
     initialize();
 }
 


### PR DESCRIPTION
type conversion from char to uint_8  for begin SSL fingerprint solved the error of ->  invalid conversion from 'const char*' to 'const uint8_t* during the compilation of Arduino esp8266 code