### PR TITLE
update to fix compile error with depricated old function

### DIFF
--- a/SocketIoClient.cpp
+++ b/SocketIoClient.cpp
@@ -53,10 +53,11 @@ void SocketIoClient::webSocketEvent(WStype_t type, uint8_t * payload, size_t len
 	}
 }
 
-void SocketIoClient::beginSSL(const char* host, const int port, const char* url, const char* fingerprint) {
-	_webSocket.beginSSL(host, port, url, fingerprint);
-    initialize();
+void SocketIoClient::beginSSL(const char* host, const int port, const char* url, const uint8_t* fingerprint, const char* protocol) {
+	_webSocket.beginSSL(host, port, url, fingerprint, protocol);
+	initialize();
 }
+
 
 void SocketIoClient::begin(const char* host, const int port, const char* url) {
 	_webSocket.begin(host, port, url);

--- a/SocketIoClient.h
+++ b/SocketIoClient.h
@@ -35,7 +35,7 @@ private:
 	void webSocketEvent(WStype_t type, uint8_t * payload, size_t length);
     void initialize();
 public:
-    void beginSSL(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL, const char* fingerprint = DEFAULT_FINGERPRINT);
+    void beginSSL(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL, const uint8_t* fingerprint = NULL, const char* protocol = "arduino");
 	void begin(const char* host, const int port = DEFAULT_PORT, const char* url = DEFAULT_URL);
 	void loop();
 	void on(const char* event, std::function<void (const char * payload, size_t length)>);


### PR DESCRIPTION
Old call function beginSSL:
```
void SocketIoClient::beginSSL(const char* host, const int port, const char* url, const char* fingerprint) {
	_webSocket.beginSSL(host, port, url, fingerprint);
    initialize();
}
```

But function beginSSL in WebSocketsClient.h:
```
void beginSSL(const char * host, uint16_t port, const char * url = "/", const uint8_t * fingerprint = NULL, const char * protocol = "arduino");
```